### PR TITLE
Dashboard skeleton

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,15 @@ function App(): JSX.Element {
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>
+                <Route exact path="/myjobs">
+                  <Dashboard />
+                </Route>
+                <Route exact path="/messages">
+                  <Dashboard />
+                </Route>
+                <Route exact path="/mysitters">
+                  <Dashboard />
+                </Route>
                 <Route path="*">
                   <Redirect to="/login" />
                 </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
+import NavBar from './components/NavBar/NavBar';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -17,19 +18,20 @@ function App(): JSX.Element {
         <SnackBarProvider>
           <AuthProvider>
             <SocketProvider>
+              <NavBar />
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path="/dashboard">
                   <Dashboard />
                 </Route>
-                <Route exact path="/myjobs">
+                <Route exact path="/my-jobs">
                   <Dashboard />
                 </Route>
                 <Route exact path="/messages">
                   <Dashboard />
                 </Route>
-                <Route exact path="/mysitters">
+                <Route exact path="/my-sitters">
                   <Dashboard />
                 </Route>
                 <Route path="*">

--- a/client/src/components/AuthMenu/AuthMenu.tsx
+++ b/client/src/components/AuthMenu/AuthMenu.tsx
@@ -3,6 +3,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
+import Avatar from '@material-ui/core/Avatar';
 import { useAuth } from '../../context/useAuthContext';
 
 const AuthMenu = (): JSX.Element => {
@@ -26,7 +27,7 @@ const AuthMenu = (): JSX.Element => {
   return (
     <div>
       <IconButton aria-label="show auth menu" aria-controls="auth-menu" aria-haspopup="true" onClick={handleClick}>
-        <MoreHorizIcon />
+        <Avatar />
       </IconButton>
       <Menu
         id="auth-menu"
@@ -40,6 +41,7 @@ const AuthMenu = (): JSX.Element => {
         }}
         getContentAnchorEl={null}
       >
+        <MenuItem>Profile</MenuItem>
         <MenuItem onClick={handleLogout}>Logout</MenuItem>
       </Menu>
     </div>

--- a/client/src/components/AuthMenu/AuthMenu.tsx
+++ b/client/src/components/AuthMenu/AuthMenu.tsx
@@ -2,7 +2,6 @@ import { useState, MouseEvent } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import Avatar from '@material-ui/core/Avatar';
 import { useAuth } from '../../context/useAuthContext';
 

--- a/client/src/components/EditProfile/EditMenu.tsx
+++ b/client/src/components/EditProfile/EditMenu.tsx
@@ -18,12 +18,9 @@ interface Props {
 
 const NavBar = ({ loggedInUser }: Props): JSX.Element => {
   const classes = useStyles();
-  console.log(loggedInUser);
 
   return (
-    <div>
-      
-    </div>
+    <Box></Box>
   );
 };
 

--- a/client/src/components/EditProfile/EditMenu.tsx
+++ b/client/src/components/EditProfile/EditMenu.tsx
@@ -21,46 +21,9 @@ const NavBar = ({ loggedInUser }: Props): JSX.Element => {
   console.log(loggedInUser);
 
   return (
-    <AppBar className={classes.appbar} position="sticky">
-      <ToolBar className={classes.toolbar}>
-        <img src={logo} alt="logo" />
-        {loggedInUser ? (
-          <Grid className={classes.navButtons}>
-            <Box p={2}>
-              <Button component={Link} to="/notifications" color="secondary" size="large" variant="text">
-                <Typography variant="h3">Notifications</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/myjobs" color="secondary" size="large" variant="text">
-                <Typography variant="h3">My Jobs</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/messages" color="secondary" size="large" variant="text">
-                <Typography variant="h3">Messages</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <AuthMenu />
-            </Box>
-          </Grid>
-        ) : (
-          <Grid className={classes.navButtons}>
-            <Box p={2}>
-              <Button component={Link} to="/login" color="primary" size="large" variant="outlined">
-                Login
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/signup" color="primary" size="large" variant="contained">
-                Sign Up
-              </Button>
-            </Box>
-          </Grid>
-        )}
-      </ToolBar>
-    </AppBar>
+    <div>
+      
+    </div>
   );
 };
 

--- a/client/src/components/EditProfile/EditMenu.tsx
+++ b/client/src/components/EditProfile/EditMenu.tsx
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import logo from '../../Images/logo.png';
+import { useAuth } from '../../context/useAuthContext';
 import { User } from '../../interface/User';
 import AuthMenu from '../AuthMenu/AuthMenu';
 
@@ -17,6 +18,7 @@ interface Props {
 
 const NavBar = ({ loggedInUser }: Props): JSX.Element => {
   const classes = useStyles();
+  console.log(loggedInUser);
 
   return (
     <AppBar className={classes.appbar} position="sticky">

--- a/client/src/components/EditProfile/EditProfile.tsx
+++ b/client/src/components/EditProfile/EditProfile.tsx
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import logo from '../../Images/logo.png';
+import { useAuth } from '../../context/useAuthContext';
 import { User } from '../../interface/User';
 import AuthMenu from '../AuthMenu/AuthMenu';
 
@@ -17,6 +18,7 @@ interface Props {
 
 const NavBar = ({ loggedInUser }: Props): JSX.Element => {
   const classes = useStyles();
+  console.log(loggedInUser);
 
   return (
     <AppBar className={classes.appbar} position="sticky">

--- a/client/src/components/EditProfile/useStyles.ts
+++ b/client/src/components/EditProfile/useStyles.ts
@@ -1,0 +1,22 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  appbar: {
+    maxHeight: 100,
+  },
+  toolbar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    height: '100%',
+    backgroundColor: '#FFFFFF',
+  },
+  navButtons: {
+    display: 'flex',
+    justifyContent: 'space-evenly',
+    alignItems: 'center',
+    marginRight: 40,
+  },
+  link: { textDecoration: 'none' },
+}));
+
+export default useStyles;

--- a/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
+++ b/client/src/components/NavBar/AuthBars/LoggedInBar.tsx
@@ -1,0 +1,41 @@
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import { Link } from 'react-router-dom';
+import useStyles from './useStyles';
+import AuthMenu from '../../AuthMenu/AuthMenu';
+
+const LoggedInBar = (): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Grid container className={classes.navButtons}>
+      <Grid item>
+        <Button component={Link} to="/notifications" color="secondary" size="large" variant="text">
+          <Typography variant="h3">Notifications</Typography>
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button component={Link} to="/my-jobs" color="secondary" size="large" variant="text">
+          <Typography variant="h3">My Jobs</Typography>
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button component={Link} to="/messages" color="secondary" size="large" variant="text">
+          <Typography variant="h3">Messages</Typography>
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button component={Link} to="/my-sitters" color="secondary" size="large" variant="text">
+          <Typography variant="h3">My Sitters</Typography>
+        </Button>
+      </Grid>
+      <Grid item>
+        <AuthMenu />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default LoggedInBar;

--- a/client/src/components/NavBar/AuthBars/LoggedOutBar.tsx
+++ b/client/src/components/NavBar/AuthBars/LoggedOutBar.tsx
@@ -1,0 +1,27 @@
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
+import { Link } from 'react-router-dom';
+import useStyles from './useStyles';
+import logo from '../../Images/logo.png';
+
+const LoggedOutBar = (): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Grid container className={classes.navButtons}>
+      <Grid item>
+        <Button component={Link} to="/login" color="primary" size="large" variant="outlined">
+          Login
+        </Button>
+      </Grid>
+      <Grid item>
+        <Button component={Link} to="/signup" color="primary" size="large" variant="contained">
+          Sign Up
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default LoggedOutBar;

--- a/client/src/components/NavBar/AuthBars/useStyles.ts
+++ b/client/src/components/NavBar/AuthBars/useStyles.ts
@@ -1,14 +1,14 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
-  appbar: {
-    maxHeight: 100,
-  },
-  toolbar: {
+  navButtons: {
     display: 'flex',
-    justifyContent: 'space-between',
-    height: '100%',
-    backgroundColor: '#FFFFFF',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    marginRight: 40,
+    '& > *': {
+      margin: 10,
+    },
   },
   link: { textDecoration: 'none' },
 }));

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -9,54 +9,29 @@ import useStyles from './useStyles';
 import logo from '../../Images/logo.png';
 import { User } from '../../interface/User';
 import AuthMenu from '../AuthMenu/AuthMenu';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useAuth } from '../../context/useAuthContext';
+import { useSocket } from '../../context/useSocketContext';
+import { useHistory } from 'react-router-dom';
+import LoggedInBar from './AuthBars/LoggedInBar';
+import LoggedOutBar from './AuthBars/LoggedOutBar';
 
 interface Props {
   loggedInUser?: User;
   handleDrawerToggle?: () => void;
 }
 
-const NavBar = ({ loggedInUser }: Props): JSX.Element => {
+const NavBar = (): JSX.Element => {
   const classes = useStyles();
+  const { loggedInUser } = useAuth();
+  const history = useHistory();
+  if (loggedInUser === undefined) return <CircularProgress />;
 
   return (
-    <AppBar className={classes.appbar} position="sticky">
+    <AppBar className={classes.appbar} position="absolute">
       <ToolBar className={classes.toolbar}>
         <img src={logo} alt="logo" />
-        {loggedInUser ? (
-          <Grid className={classes.navButtons}>
-            <Box p={2}>
-              <Button component={Link} to="/notifications" color="secondary" size="large" variant="text">
-                <Typography variant="h3">Notifications</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/myjobs" color="secondary" size="large" variant="text">
-                <Typography variant="h3">My Jobs</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/messages" color="secondary" size="large" variant="text">
-                <Typography variant="h3">Messages</Typography>
-              </Button>
-            </Box>
-            <Box p={2}>
-              <AuthMenu />
-            </Box>
-          </Grid>
-        ) : (
-          <Grid className={classes.navButtons}>
-            <Box p={2}>
-              <Button component={Link} to="/login" color="primary" size="large" variant="outlined">
-                Login
-              </Button>
-            </Box>
-            <Box p={2}>
-              <Button component={Link} to="/signup" color="primary" size="large" variant="contained">
-                Sign Up
-              </Button>
-            </Box>
-          </Grid>
-        )}
+        {loggedInUser ? <LoggedInBar /> : <LoggedOutBar />}
       </ToolBar>
     </AppBar>
   );

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -3,30 +3,65 @@ import AppBar from '@material-ui/core/AppBar';
 import ToolBar from '@material-ui/core/Toolbar';
 import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 import useStyles from './useStyles';
 import logo from '../../Images/logo.png';
+import { useAuth } from '../../context/useAuthContext';
+import { User } from '../../interface/User';
+import AuthMenu from '../AuthMenu/AuthMenu';
 
-export default function NavBar(): JSX.Element {
+interface Props {
+  loggedInUser?: User;
+  handleDrawerToggle?: () => void;
+}
+
+const NavBar = ({ loggedInUser }: Props): JSX.Element => {
   const classes = useStyles();
+  console.log(loggedInUser);
 
   return (
-    <AppBar position="static">
+    <AppBar className={classes.appbar} position="sticky">
       <ToolBar className={classes.toolbar}>
         <img src={logo} alt="logo" />
-        <Grid className={classes.loginSignup}>
-          <Box p={1}>
-            <Button component={Link} to="/login" color="primary" size="large" variant="outlined">
-              Login
-            </Button>
-          </Box>
-          <Box p={1}>
-            <Button component={Link} to="/signup" color="primary" size="large" variant="contained">
-              Sign Up
-            </Button>
-          </Box>
-        </Grid>
+        {loggedInUser ? (
+          <Grid className={classes.navButtons}>
+            <Box p={2}>
+              <Button component={Link} to="/notifications" color="secondary" size="large" variant="text">
+                <Typography variant="h3">Notifications</Typography>
+              </Button>
+            </Box>
+            <Box p={2}>
+              <Button component={Link} to="/myjobs" color="secondary" size="large" variant="text">
+                <Typography variant="h3">My Jobs</Typography>
+              </Button>
+            </Box>
+            <Box p={2}>
+              <Button component={Link} to="/messages" color="secondary" size="large" variant="text">
+                <Typography variant="h3">Messages</Typography>
+              </Button>
+            </Box>
+            <Box p={2}>
+              <AuthMenu />
+            </Box>
+          </Grid>
+        ) : (
+          <Grid className={classes.navButtons}>
+            <Box p={2}>
+              <Button component={Link} to="/login" color="primary" size="large" variant="outlined">
+                Login
+              </Button>
+            </Box>
+            <Box p={2}>
+              <Button component={Link} to="/signup" color="primary" size="large" variant="contained">
+                Sign Up
+              </Button>
+            </Box>
+          </Grid>
+        )}
       </ToolBar>
     </AppBar>
   );
-}
+};
+
+export default NavBar;

--- a/client/src/components/NavBar/useStyles.ts
+++ b/client/src/components/NavBar/useStyles.ts
@@ -1,17 +1,20 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
+  appbar: {
+    maxHeight: 100,
+  },
   toolbar: {
     display: 'flex',
     justifyContent: 'space-between',
-    minHeight: 56,
+    height: '100%',
     backgroundColor: '#FFFFFF',
   },
-  loginSignup: {
+  navButtons: {
     display: 'flex',
-    justifyContent: 'flex-start',
-    marginRight: 20,
-    textTransform: 'uppercase',
+    justifyContent: 'space-evenly',
+    alignItems: 'center',
+    marginRight: 40,
   },
   link: { textDecoration: 'none' },
 }));

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,14 +1,21 @@
 import Grid from '@material-ui/core/Grid';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import Paper from '@material-ui/core/Paper';
+import { Box, Typography } from '@material-ui/core';
 import useStyles from './useStyles';
 import { useAuth } from '../../context/useAuthContext';
 import { useSocket } from '../../context/useSocketContext';
 import { useHistory } from 'react-router-dom';
 import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
-import { useEffect } from 'react';
+import { useEffect, FunctionComponent, Component } from 'react';
+import NavBar from '../../components/NavBar/NavBar';
 
-export default function Dashboard(): JSX.Element {
+interface Props {
+  component?: FunctionComponent | Component;
+}
+
+export default function Dashboard(component: Props): JSX.Element {
   const classes = useStyles();
 
   const { loggedInUser } = useAuth();
@@ -30,8 +37,14 @@ export default function Dashboard(): JSX.Element {
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />
-      <Grid item className={classes.drawerWrapper}>
-        <ChatSideBanner loggedInUser={loggedInUser} />
+      <NavBar loggedInUser={loggedInUser} />
+      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
+        <Box width="100%" maxWidth={450} p={3} alignSelf="center">
+          <Grid container>
+            <Grid item xs></Grid>
+          </Grid>
+        </Box>
+        <Box p={1} alignSelf="center" />
       </Grid>
     </Grid>
   );

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -2,12 +2,11 @@ import Grid from '@material-ui/core/Grid';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Paper from '@material-ui/core/Paper';
-import { Box, Typography } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 import useStyles from './useStyles';
 import { useAuth } from '../../context/useAuthContext';
 import { useSocket } from '../../context/useSocketContext';
 import { useHistory } from 'react-router-dom';
-import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import { useEffect, FunctionComponent, Component } from 'react';
 import NavBar from '../../components/NavBar/NavBar';
 

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -36,15 +36,6 @@ export default function Dashboard(component: Props): JSX.Element {
   return (
     <Grid container component="main" className={`${classes.root} ${classes.dashboard}`}>
       <CssBaseline />
-      <NavBar loggedInUser={loggedInUser} />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
-        <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-          <Grid container>
-            <Grid item xs></Grid>
-          </Grid>
-        </Box>
-        <Box p={1} alignSelf="center" />
-      </Grid>
     </Grid>
   );
 }

--- a/client/src/pages/Dashboard/useStyles.ts
+++ b/client/src/pages/Dashboard/useStyles.ts
@@ -1,8 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const drawerWidth = 240;
-
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     minHeight: '100vh',
   },

--- a/client/src/pages/Dashboard/useStyles.ts
+++ b/client/src/pages/Dashboard/useStyles.ts
@@ -5,16 +5,11 @@ const drawerWidth = 240;
 const useStyles = makeStyles((theme) => ({
   root: {
     minHeight: '100vh',
-    '& .MuiInput-underline:before': {
-      borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
-    },
   },
-  dashboard: { backgroundColor: '#FFFFFF' },
-  drawerWrapper: {
-    width: drawerWidth,
-    [theme.breakpoints.up('md')]: {
-      width: '300px',
-    },
+  dashboard: {
+    backgroundColor: '#FFFFFF',
+    flexDirection: 'column',
+    alignItems: 'center',
   },
 }));
 

--- a/client/src/pages/Dashboard/useStyles.ts
+++ b/client/src/pages/Dashboard/useStyles.ts
@@ -7,6 +7,7 @@ const useStyles = makeStyles(() => ({
   dashboard: {
     backgroundColor: '#FFFFFF',
     flexDirection: 'column',
+    justifyContent: 'center',
     alignItems: 'center',
   },
 }));

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -39,7 +39,6 @@ export default function Login(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <NavBar />
       <Grid item xs={12} sm={8} md={7} elevation={4} component={Paper} square>
         <Box className={classes.authWrapper}>
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles(() => ({
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
     justifyContent: 'center',
-    alignItems: 'flex-start',
+    alignItems: 'center',
   },
   authWrapper: {
     display: 'flex',

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -40,7 +40,6 @@ export default function Register(): JSX.Element {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <NavBar />
       <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
         <Box className={classes.authWrapper}>
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles(() => ({
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
     justifyContent: 'center',
-    alignItems: 'flex-start',
+    alignItems: 'center',
   },
   authWrapper: {
     display: 'flex',

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -6,10 +6,17 @@ export const theme = createMuiTheme({
     fontSize: 12,
     button: {
       fontFamily: '"Roboto"',
-      fontWeight: 'bold',
     },
     body1: {
       color: '#f14140',
+    },
+    h3: {
+      fontSize: 18,
+      color: '#000000',
+      fontWeight: 500,
+      fontFamily: "'Arial'",
+      textAlign: 'center',
+      textTransform: 'capitalize',
     },
     h5: {
       fontSize: 26,
@@ -21,6 +28,7 @@ export const theme = createMuiTheme({
   },
   palette: {
     primary: { main: '#f14140' },
+    secondary: { main: '#FFFFFF' },
   },
   shape: {
     borderRadius: 5,


### PR DESCRIPTION
### What this PR does (required):
- Creates the dashboard skeleton and adds routes for the content pages(content components to be added later).

### Screenshots / Videos (front-end only):

Dashboard:
![Screen Shot 2021-11-11 at 11 21 47 AM](https://user-images.githubusercontent.com/38635538/141356696-8ecf0867-2c17-4a05-a5e7-15f7a05f4b8c.png)

Profile picture drop down menu:
![Screen Shot 2021-11-11 at 11 22 19 AM](https://user-images.githubusercontent.com/38635538/141356762-e17d5b3b-f16b-423f-afc2-51dafa4165a1.png)


### Any information needed to test this feature (required):
- Sign up and logout the user
- Navigate to the various navbar endpoints(need to create them first)
